### PR TITLE
stats update store procedure is chabged for the 3 months logic

### DIFF
--- a/updated_usp_AutoUpadeteStats
+++ b/updated_usp_AutoUpadeteStats
@@ -1,0 +1,40 @@
+-- This is the stor pro to autoupdate the stats of the object
+-- whose stats are not been updateed since last 90 days
+Create procedure usp_AutoUpadeteStats
+(@IntObjectid int) 
+as
+   begin 
+       declare @LastUpdatedate  as date
+	   declare @StatName as varchar (100)
+	   declare @strmessage as varchar (2000)
+	   declare @intID as int
+	set @intID = @IntObjectid   
+select @LastUpdatedate=
+stats_date ([object_id], [stats_id])
+from sys.stats
+where [object_id]=@IntObjectid;
+
+select @StatName=
+[name]
+from sys.stats
+where [object_id]=@IntObjectid;
+   
+   if @LastUpdatedate>= DATEADD ( day, -90, getdate ())
+         begin 
+		 Raiserror ( 'Please update the statistics of the table, it is outdated', 16,1);
+
+		 end 
+
+		 else 
+		  set  @strmessage= 'All the stats of' + object_name (@intID)  +' is updated' 
+		    
+		    raiserror (@strmessage, 0,1) 
+
+	  end ;
+
+
+select [object_id],stats_date ([object_id], [stats_id])  as 'Date'
+from sys.stats
+order by [Date] desc 
+
+---note this will not insure the automation of the stats update 


### PR DESCRIPTION
PR for the   store procedure "usp_AutoUpadeteStats" logic to make it update the stats of the objects whose stats are not updated for the tree months.